### PR TITLE
refactor: improve children typings

### DIFF
--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactChild, ReactChildren } from 'react';
+import React, { FC } from 'react';
 
 import ThemeContext from 'ThemeContext';
 
@@ -15,18 +15,17 @@ export interface LinkProps {
   href: string;
   target: TargetTypes;
   className?: string;
-  children: ReactChildren | ReactChild;
 }
 
 const Link: FC<LinkProps> = ({ href, target, children, className = '' }) => {
   return (
     <ThemeContext.Consumer>
-      {(context) => {
+      {({ theme }) => {
         return (
           <a
             target={target}
             href={href}
-            className={`link link--${context.theme} ${className}`}
+            className={`link link--${theme} ${className}`}
             rel="noopener noreferrer"
           >
             {children}

--- a/src/test/providers/I18nProvider.tsx
+++ b/src/test/providers/I18nProvider.tsx
@@ -1,10 +1,8 @@
-import React, { ReactChild, FC } from 'react';
+import React, { FC } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from 'i18n';
 
-export interface I18nProviderProps {
-  children: ReactChild;
-}
+export interface I18nProviderProps {}
 
 const I18nProvider: FC<I18nProviderProps> = ({ children }) => (
   <I18nextProvider i18n={i18n}>{children}</I18nextProvider>

--- a/src/test/providers/ThemeProvider.tsx
+++ b/src/test/providers/ThemeProvider.tsx
@@ -1,8 +1,7 @@
-import React, { ReactChild, FC } from 'react';
+import React, { FC } from 'react';
 import ThemeContext, { Themes } from 'ThemeContext';
 
 export interface ThemeProviderProps {
-  children: ReactChild;
   theme?: Themes;
   setTheme?: (theme: Themes) => void;
 }


### PR DESCRIPTION
# Improve children typings

## 📖 Description/Context

Some components were using an incorrect retyping of children,
this should be inherited by React.FC