### PR TITLE
refactor: add cleaner import/exports

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 import { render, waitFor, fireEvent } from '@testing-library/react';
-import App from './App';
+import { App } from './App';
 
 /** @todo Increase coverage */
 describe('App', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,17 @@
 import React, { lazy, Suspense, useState, useEffect } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
-import ThemeContext, { Themes, Palette } from 'ThemeContext';
-import GlobalSelectors from 'components/GlobalSelectors/GlobalSelectors';
-import Loading from 'components/Loading/Loading';
-import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
+import { ThemeContext, Themes, Palette } from 'ThemeContext';
+import { GlobalSelectors } from 'components/GlobalSelectors';
+import { Loading } from 'components/Loading';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 import './App.scss';
 
 const Home = lazy(() => import('pages/Home'));
 
-function App() {
+type AppProps = {};
+
+export const App: React.FC<AppProps> = () => {
   const [theme, setTheme] = useState(Themes.LIGHT);
 
   useEffect(() => {
@@ -40,6 +42,4 @@ function App() {
       </ThemeContext.Provider>
     </div>
   );
-}
-
-export default App;
+};

--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -20,9 +20,7 @@ export enum Palette {
 }
 
 /* istanbul ignore next */
-const ThemeContext = React.createContext({
+export const ThemeContext = React.createContext({
   theme: Themes.LIGHT,
   setTheme: (theme: Themes) => {},
 });
-
-export default ThemeContext;

--- a/src/components/Description/Description.test.tsx
+++ b/src/components/Description/Description.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 import { render } from '@testing-library/react';
-import Description from './Description';
+import { Description } from './index';
 
 describe('Description', () => {
   const renderComponent = () =>

--- a/src/components/Description/Description.tsx
+++ b/src/components/Description/Description.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next';
 
 import './Description.scss';
 
-export interface DescriptionProps {}
+export type DescriptionProps = {};
 
-const Description: FC<DescriptionProps> = () => {
+export const Description: FC<DescriptionProps> = () => {
   const { t } = useTranslation();
 
   return (
@@ -15,5 +15,3 @@ const Description: FC<DescriptionProps> = () => {
     </section>
   );
 };
-
-export default Description;

--- a/src/components/Description/index.ts
+++ b/src/components/Description/index.ts
@@ -1,0 +1,1 @@
+export { Description } from './Description';

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 import React from 'react';
 import { render } from '@testing-library/react';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 
-import ErrorBoundary from './ErrorBoundary';
+import { ErrorBoundary } from './index';
 
 let consoleSpy: jest.SpyInstance<void, [any?, ...any[]]>; // eslint-disable-line @typescript-eslint/no-explicit-any
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,16 +2,19 @@ import React, { Component } from 'react';
 
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import Link, { TargetTypes } from 'components/Link/Link';
-import Heading, { Levels } from 'components/Heading/Heading';
+import { Link, TargetTypes } from 'components/Link/Link';
+import { Heading, Levels } from 'components/Heading/Heading';
 
 export interface ErrorBoundaryProps extends WithTranslation {}
 
-export interface ErrorBoundaryState {
+export type ErrorBoundaryState = {
   hasError: boolean;
-}
+};
 
-class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+export class _ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
 
@@ -56,4 +59,4 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 }
 
-export default withTranslation()(ErrorBoundary);
+export const ErrorBoundary = withTranslation()(_ErrorBoundary);

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -12,8 +12,8 @@ export type ErrorBoundaryState = {
 };
 
 export class _ErrorBoundary extends Component<
-  ErrorBoundaryProps,
-  ErrorBoundaryState
+ErrorBoundaryProps,
+ErrorBoundaryState
 > {
   constructor(props: ErrorBoundaryProps) {
     super(props);

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+export { ErrorBoundary } from './ErrorBoundary';
+// import type { ErrorBoundaryProps } from './ErrorBoundary';

--- a/src/components/GlobalSelectors/GlobalSelectors.tsx
+++ b/src/components/GlobalSelectors/GlobalSelectors.tsx
@@ -1,13 +1,13 @@
 import React, { FC } from 'react';
 
-import LanguageSelector from 'components/LanguageSelector/LanguageSelector';
-import ThemeSelector from 'components/ThemeSelector/ThemeSelector';
+import { LanguageSelector } from 'components/LanguageSelector';
+import { ThemeSelector } from 'components/ThemeSelector';
 
 import './GlobalSelectors.scss';
 
-export interface GlobalSelectorsProps {}
+export type GlobalSelectorsProps = {};
 
-const GlobalSelectors: FC<GlobalSelectorsProps> = () => {
+export const GlobalSelectors: FC<GlobalSelectorsProps> = () => {
   return (
     <section className="global-selectors">
       <LanguageSelector />
@@ -15,5 +15,3 @@ const GlobalSelectors: FC<GlobalSelectorsProps> = () => {
     </section>
   );
 };
-
-export default GlobalSelectors;

--- a/src/components/GlobalSelectors/index.ts
+++ b/src/components/GlobalSelectors/index.ts
@@ -1,0 +1,1 @@
+export { GlobalSelectors } from './GlobalSelectors';

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 import { render } from '@testing-library/react';
-import Heading, { Levels } from './Heading';
+import { Heading, Levels } from './index';
 
 describe('Heading', () => {
   const renderComponent = (

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -12,13 +12,13 @@ export enum Levels {
   THREE = '3',
 }
 
-export interface HeadingProps {
+export type HeadingProps = {
   level: Levels;
   locKey: string;
   screenReaderOnly?: boolean;
-}
+};
 
-const Heading: FC<HeadingProps> = ({
+export const Heading: FC<HeadingProps> = ({
   level,
   locKey,
   screenReaderOnly = false,
@@ -30,5 +30,3 @@ const Heading: FC<HeadingProps> = ({
 
   return createElement(heading, { className }, t(locKey));
 };
-
-export default Heading;

--- a/src/components/Heading/index.ts
+++ b/src/components/Heading/index.ts
@@ -1,0 +1,1 @@
+export { Heading, Levels } from './Heading';

--- a/src/components/LanguageSelector/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 import { render, fireEvent } from '@testing-library/react';
-import LanguageSelector from './LanguageSelector';
+import { LanguageSelector } from './index';
 
 describe('Heading', () => {
   const renderComponent = () =>

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import LOCALES from 'locales/locales';
-import Select from 'components/Select/Select';
+import { Select } from 'components/Select/Select';
 
-export interface LanguageSelectorProps {}
+export type LanguageSelectorProps = {};
 
-const LanguageSelector: FC<LanguageSelectorProps> = () => {
+export const LanguageSelector: FC<LanguageSelectorProps> = () => {
   const { t, i18n } = useTranslation();
   const { language } = i18n;
 
@@ -28,5 +28,3 @@ const LanguageSelector: FC<LanguageSelectorProps> = () => {
     />
   );
 };
-
-export default LanguageSelector;

--- a/src/components/LanguageSelector/index.ts
+++ b/src/components/LanguageSelector/index.ts
@@ -1,0 +1,1 @@
+export { LanguageSelector } from './LanguageSelector';

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { ThemeProvider } from 'test/Providers';
-import Link, { TargetTypes } from './Link';
+import { ThemeProvider } from 'test/providers';
+import { Link, TargetTypes } from './index';
 
 describe('Link', () => {
   it('should render, including default theme and custom css classes', () => {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import ThemeContext from 'ThemeContext';
+import { ThemeContext } from 'ThemeContext';
 
 import './Link.scss';
 
@@ -11,13 +11,18 @@ export enum TargetTypes {
   TOP = '_top',
 }
 
-export interface LinkProps {
+export type LinkProps = {
   href: string;
   target: TargetTypes;
   className?: string;
-}
+};
 
-const Link: FC<LinkProps> = ({ href, target, children, className = '' }) => {
+export const Link: FC<LinkProps> = ({
+  href,
+  target,
+  children,
+  className = '',
+}) => {
   return (
     <ThemeContext.Consumer>
       {({ theme }) => {
@@ -35,5 +40,3 @@ const Link: FC<LinkProps> = ({ href, target, children, className = '' }) => {
     </ThemeContext.Consumer>
   );
 };
-
-export default Link;

--- a/src/components/Link/index.ts
+++ b/src/components/Link/index.ts
@@ -1,0 +1,1 @@
+export { TargetTypes, Link } from './Link';

--- a/src/components/Loading/Loading.test.tsx
+++ b/src/components/Loading/Loading.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import Loading from './Loading';
+import { Loading } from './index';
 
 describe('Loading', () => {
   jest.useFakeTimers();

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,13 +1,13 @@
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import useEllipsis from './useEllipsis';
+import { useEllipsis } from './useEllipsis';
 
 import './Loading.scss';
 
-export interface LoadingProps {}
+export type LoadingProps = {};
 
-const Loading: FC<LoadingProps> = () => {
+export const Loading: FC<LoadingProps> = () => {
   const { t } = useTranslation();
   const ellipsis = useEllipsis();
 
@@ -19,5 +19,3 @@ const Loading: FC<LoadingProps> = () => {
     </section>
   );
 };
-
-export default Loading;

--- a/src/components/Loading/index.ts
+++ b/src/components/Loading/index.ts
@@ -1,0 +1,1 @@
+export { Loading } from './Loading';

--- a/src/components/Loading/useEllipsis.test.tsx
+++ b/src/components/Loading/useEllipsis.test.tsx
@@ -1,5 +1,5 @@
 import { testHook } from 'test/TestHook';
-import useEllipsis from './useEllipsis';
+import { useEllipsis } from './useEllipsis';
 
 describe('useEllipsis', () => {
   jest.useFakeTimers();

--- a/src/components/Loading/useEllipsis.ts
+++ b/src/components/Loading/useEllipsis.ts
@@ -20,7 +20,7 @@ const getEllipsis = (count: number): string => {
 };
 
 /* istanbul ignore next */
-const useEllipsis = () => {
+export const useEllipsis = () => {
   const INTERVAL = 1000;
   const [ellipsisCount, setEllipsis] = useState<number>(1);
 
@@ -38,5 +38,3 @@ const useEllipsis = () => {
 
   return getEllipsis(ellipsisCount);
 };
-
-export default useEllipsis;

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 import { render } from '@testing-library/react';
-import Logo from './Logo';
+import { Logo } from './index';
 
 describe('Logo', () => {
   it('should render', () => {

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,22 +1,22 @@
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import ThemeContext from 'ThemeContext';
+import { ThemeContext } from 'ThemeContext';
 
 import './Logo.scss';
 import lightLogo from 'img/logo.png';
 import darkLogo from 'img/logo_dark.png';
 
-const logos = {
+const logos: Record<'light' | 'dark', string> = {
   light: lightLogo,
   dark: darkLogo,
 };
 
-export interface LogoProps {
+export type LogoProps = {
   href: string;
-}
+};
 
-const Logo: FC<LogoProps> = ({ href }) => {
+export const Logo: FC<LogoProps> = ({ href }) => {
   const { t } = useTranslation();
 
   return (
@@ -40,5 +40,3 @@ const Logo: FC<LogoProps> = ({ href }) => {
     </ThemeContext.Consumer>
   );
 };
-
-export default Logo;

--- a/src/components/Logo/index.ts
+++ b/src/components/Logo/index.ts
@@ -1,0 +1,1 @@
+export { Logo } from './Logo';

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import Select, { SelectOptionProps } from './Select';
+import { Select } from './index';
 
 describe('renders learn react link', () => {
-  const options: SelectOptionProps[] = [
+  const options = [
     {
       value: 'first',
       displayValue: '1st',

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,20 +1,18 @@
 import React, { FC, FormEvent, useState } from 'react';
 
-import SelectOption, {
-  SelectOptionProps as SelectOptionPropsDefinition,
-} from './SelectOption';
+import { SelectOption, SelectOptionProps } from './SelectOption';
 
 import './Select.scss';
 
-export interface SelectProps {
+export type SelectProps = {
   className: string;
   initialValue: string;
   options: SelectOptionProps[];
   ariaLabel: string;
   onChange?: (newValue: string) => void;
-}
+};
 
-const Select: FC<SelectProps> = ({
+export const Select: FC<SelectProps> = ({
   className,
   initialValue,
   options,
@@ -45,6 +43,3 @@ const Select: FC<SelectProps> = ({
     </select>
   );
 };
-
-export type SelectOptionProps = SelectOptionPropsDefinition;
-export default Select;

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -1,12 +1,13 @@
 import React, { FC } from 'react';
 
-export interface SelectOptionProps {
+export type SelectOptionProps = {
   value: string;
   displayValue: string;
-}
+};
 
-const SelectOption: FC<SelectOptionProps> = ({ value, displayValue }) => (
-  <option value={value}>{displayValue}</option>
-);
+export const SelectOption: FC<SelectOptionProps> = ({
+  value,
+  displayValue,
+}) => <option value={value}>{displayValue}</option>;
 
 export default SelectOption;

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,0 +1,1 @@
+export { Select } from './Select';

--- a/src/components/SocialNetworks/SocialNetworks.test.tsx
+++ b/src/components/SocialNetworks/SocialNetworks.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { I18nProvider } from 'test/Providers';
+import { I18nProvider } from 'test/providers';
 
-import SocialNetworks from './SocialNetworks';
+import { SocialNetworks } from './index';
 
 describe('SocialNetworks', () => {
   const renderComponent = () =>

--- a/src/components/SocialNetworks/SocialNetworks.tsx
+++ b/src/components/SocialNetworks/SocialNetworks.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react';
 
-import Heading, { Levels } from 'components/Heading/Heading';
-import Link, { TargetTypes } from 'components/Link/Link';
+import { Heading, Levels } from 'components/Heading';
+import { Link, TargetTypes } from 'components/Link';
 
 import './SocialNetworks.scss';
 import { socialNetworks } from './list';
 
-export interface SocialNetworksProps {}
+export type SocialNetworksProps = {};
 
-const SocialNetworks: FC<SocialNetworksProps> = () => {
+export const SocialNetworks: FC<SocialNetworksProps> = () => {
   return (
     <section className="social-networks">
       <Heading level={Levels.TWO} locKey="social_networks_heading" />
@@ -25,5 +25,3 @@ const SocialNetworks: FC<SocialNetworksProps> = () => {
     </section>
   );
 };
-
-export default SocialNetworks;

--- a/src/components/SocialNetworks/index.ts
+++ b/src/components/SocialNetworks/index.ts
@@ -1,0 +1,1 @@
+export { SocialNetworks } from './SocialNetworks';

--- a/src/components/ThemeSelector/ThemeSelector.test.tsx
+++ b/src/components/ThemeSelector/ThemeSelector.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { ThemeProvider, I18nProvider } from 'test/Providers';
-import ThemeSelector from './ThemeSelector';
+import { ThemeProvider, I18nProvider } from 'test/providers';
+import { ThemeSelector } from './index';
 
 describe('ThemeSelector', () => {
   const renderComponent = () =>

--- a/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/src/components/ThemeSelector/ThemeSelector.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react';
-import Select, { SelectOptionProps } from 'components/Select/Select';
-import ThemeContext, { Themes } from 'ThemeContext';
+import { Select } from 'components/Select';
+import { ThemeContext, Themes } from 'ThemeContext';
 import { useTranslation } from 'react-i18next';
 
-export interface ThemeSelectorProps {}
+export type ThemeSelectorProps = {};
 
-const ThemeSelector: FC<ThemeSelectorProps> = () => {
+export const ThemeSelector: FC<ThemeSelectorProps> = () => {
   const { t } = useTranslation();
 
-  const options: SelectOptionProps[] = [
+  const options = [
     {
       displayValue: t('theme_selector_light'),
       value: Themes.LIGHT,
@@ -35,5 +35,3 @@ const ThemeSelector: FC<ThemeSelectorProps> = () => {
     </ThemeContext.Consumer>
   );
 };
-
-export default ThemeSelector;

--- a/src/components/ThemeSelector/index.ts
+++ b/src/components/ThemeSelector/index.ts
@@ -1,0 +1,1 @@
+export { ThemeSelector } from './ThemeSelector';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './i18n';
-import App from './App';
+import { App } from './App';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import Heading, { Levels } from 'components/Heading/Heading';
-import Logo from 'components/Logo/Logo';
-import SocialNetworks from 'components/SocialNetworks/SocialNetworks';
-import Description from 'components/Description/Description';
+import { Heading, Levels } from 'components/Heading';
+import { Logo } from 'components/Logo';
+import { SocialNetworks } from 'components/SocialNetworks';
+import { Description } from 'components/Description';
 
 export default function Home() {
   return (

--- a/src/test/Providers.tsx
+++ b/src/test/Providers.tsx
@@ -1,4 +1,0 @@
-import I18nProvider from 'test/providers/I18nProvider';
-import ThemeProvider from 'test/providers/ThemeProvider';
-
-export { I18nProvider, ThemeProvider };

--- a/src/test/providers/I18nProvider.tsx
+++ b/src/test/providers/I18nProvider.tsx
@@ -2,10 +2,8 @@ import React, { FC } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from 'i18n';
 
-export interface I18nProviderProps {}
+export type I18nProviderProps = {};
 
-const I18nProvider: FC<I18nProviderProps> = ({ children }) => (
+export const I18nProvider: FC<I18nProviderProps> = ({ children }) => (
   <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
 );
-
-export default I18nProvider;

--- a/src/test/providers/ThemeProvider.tsx
+++ b/src/test/providers/ThemeProvider.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react';
-import ThemeContext, { Themes } from 'ThemeContext';
+import { ThemeContext, Themes } from 'ThemeContext';
 
 export interface ThemeProviderProps {
   theme?: Themes;
   setTheme?: (theme: Themes) => void;
 }
 
-const ThemeProvider: FC<ThemeProviderProps> = ({
+export const ThemeProvider: FC<ThemeProviderProps> = ({
   children,
   theme = Themes.LIGHT,
   setTheme = () => {},
@@ -19,5 +19,3 @@ const ThemeProvider: FC<ThemeProviderProps> = ({
     </ThemeContext.Provider>
   );
 };
-
-export default ThemeProvider;

--- a/src/test/providers/index.ts
+++ b/src/test/providers/index.ts
@@ -1,0 +1,2 @@
+export { I18nProvider } from './I18nProvider';
+export { ThemeProvider } from './ThemeProvider';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ESNext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -9,12 +13,14 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
     "baseUrl": "src"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
# Cleanup import/export

## 📖 Description/Context

- Simplify exports by adding an `index` file on each module
- Update typescript configuration to support the latest available features
- Replace interfaces with types

## Issue tracker

Closes: #75 
